### PR TITLE
Normalize newlines in pd-rendering-test.js.

### DIFF
--- a/test/pd-rendering-test.js
+++ b/test/pd-rendering-test.js
@@ -3,21 +3,19 @@ var path = require('path')
   , assert = require('assert')
   , parsing = require('../lib/parsing')
   , pdRendering = require('../lib/pd-rendering')
-
-// http://stackoverflow.com/a/21895354
-function normalizeNewlines(str) {
-  return str.split(/\r?\n/).join('\n');
-}
+  , NEWLINE_REGEX = /\r?\n/;
 
 describe('pd-rendering', function() {
 
   describe('#render', function() {
 
     it('should succeed parsing/rendering all test patches identically', function() {
-      // TODO
       var patchFile = fs.readFileSync(path.join(__dirname, 'patches', 'simple.pd')).toString()
         , simplePatch = parsing.parse(patchFile)
-      assert.equal(pdRendering.render(simplePatch), normalizeNewlines(patchFile))
+      assert.deepEqual(
+        pdRendering.render(simplePatch).split(NEWLINE_REGEX),
+        patchFile.split(NEWLINE_REGEX)
+      );
     })
 
   })

--- a/test/pd-rendering-test.js
+++ b/test/pd-rendering-test.js
@@ -4,6 +4,11 @@ var path = require('path')
   , parsing = require('../lib/parsing')
   , pdRendering = require('../lib/pd-rendering')
 
+// http://stackoverflow.com/a/21895354
+function normalizeNewlines(str) {
+  return str.split(/\r?\n/).join('\n');
+}
+
 describe('pd-rendering', function() {
 
   describe('#render', function() {
@@ -12,7 +17,7 @@ describe('pd-rendering', function() {
       // TODO
       var patchFile = fs.readFileSync(path.join(__dirname, 'patches', 'simple.pd')).toString()
         , simplePatch = parsing.parse(patchFile)
-      assert.equal(pdRendering.render(simplePatch), patchFile)
+      assert.equal(pdRendering.render(simplePatch), normalizeNewlines(patchFile))
     })
 
   })


### PR DESCRIPTION
The test file doesn't normalize newlines based on the current OS, which makes the test fail on Windows.