### PR TITLE
Tests now work in node 0.12.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "underscore": "1.4.x",
-    "d3": "3.0.x",
+    "d3": "3.5.3",
     "mustache": "0.7.x"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes sebpiq/WebPd#67 by using a new version of d3.

However, d3 recently changed in 3.5.4 such that it no longer includes jsdom as an explicit dependency; instead, it expects the client to either

* [explicitly pass-in a DOM implementation to d3 methods](https://github.com/mbostock/d3/pull/2225#issuecomment-73426201), or
* [hack the global object to provide `document` and/or `window`](https://github.com/mbostock/d3/pull/2225/files#diff-168726dbe96b3ce427e7fedce31bb0bc).

Anyways, I wasn't sure which you'd prefer, if either, and it was enough of a hassle that I just locked d3 at 3.5.3--the version immediately before this change--instead of dealing with the problem. :eyes: 

Obviously that's suboptimal for various reasons, so if you don't like this PR, please let me know which strategy you prefer and I'll implement it in a different PR.