### PR TITLE
bump d3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "pd-fileutils.parser": "0.3.4",
     "underscore": "1.4.x",
-    "d3": "3.5.3",
+    "d3": "5.9.2",
     "mustache": "0.7.x"
   },
   "devDependencies": {


### PR DESCRIPTION
A bug in jsdom (dependency on contextify) prevents proper build on node > 6.7
d3 version update wil probably solve this
348 silly saveTree └─┬ pd-fileutils@0.3.5
348 silly saveTree   ├─┬ d3@3.5.3
348 silly saveTree   │ └─┬ jsdom@1.0.0